### PR TITLE
Add legally required attribution

### DIFF
--- a/wp-content/themes/wp-nycc/map_scripts.php
+++ b/wp-content/themes/wp-nycc/map_scripts.php
@@ -139,11 +139,13 @@ if ( is_page_template( 'page-district.php' ) || is_page_template( 'page-speakerd
       layers: [
           L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png', {
             minZoom: 13,
-            maxZoom: 17
+            maxZoom: 17,
+            attribution: '© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, © <a href="https://carto.com/about-carto/">CARTO</a>',
           }),
           L.tileLayer('https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_nolabels/{z}/{x}/{y}.png', {
             maxZoom: 12,
-            minZoom: 10
+            minZoom: 10,
+            attribution: '© <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>, © <a href="https://carto.com/about-carto/">CARTO</a>',
           })
       ]
     }).setView([40.727760, -73.987218], 11 );


### PR DESCRIPTION
Dear New York City Council,

As the chairperson of the OpenStreetMap Foundation, I'm writing to express our pride and, on this thanksgiving, our thankfulness for your use of OpenStreetMap (OSM) data on council.nyc.gov. Our maps underpin your website's functionality, highlighting the critical role of OSM in civic engagement.

OpenStreetMap owes its success to our millions of volunteers, including normal New Yorkers like you and I, who share our vision and invest their time to maintain and improve the data. Many became contributors after starting as users. While most OSM-based maps are independently deployed, operators recognise the benefit of highlighting their use of OpenStreetMap. We believe end users realise that they can improve their experience by improving the map data. Thus, there are compelling reasons to attribute OpenStreetMap, even beyond the legal obligation. Unfortunately council.nyc.gov does not provide this required attribution.

We very much regret that the obligatory attribution of OpenStreetMap is missing from your maps. Just as you would credit a photographer when using his or her images, you are required to do the same when you use OpenStreetMap data. Our licence, although “Free and Open” carries a small number of conditions, one of which is the requirement to provide correct attribution.

We are sure that you will recognise the importance of rectifying this oversight and bringing council.nyc.gov into compliance with the licence under which our data is made available to you. Remember, not only is this a legal condition of your use of OSM, it also respects the volunteers who made your map and it helps encourage your users to improve it. Full details on how to attribute OpenStreetMap can be found in the [Attribution Guidelines](https://osmfoundation.org/wiki/Licence/Attribution_Guidelines).

Thank you , and happy thanksgiving,

Guillaume Rischard, chairperson, OpenStreetMap Foundation